### PR TITLE
Implement persistent awaitable constraint.

### DIFF
--- a/RateLimiter/PersistentCountByIntervalAwaitableConstraint.cs
+++ b/RateLimiter/PersistentCountByIntervalAwaitableConstraint.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RateLimiter
+{
+    /// <summary>
+    /// <see cref="CountByIntervalAwaitableConstraint"/> that is able to save own state.
+    /// </summary>
+    public class PersistentCountByIntervalAwaitableConstraint : CountByIntervalAwaitableConstraint
+    {
+        private readonly Action<DateTime> _saveStateAction;
+
+        /// <summary>
+        /// Create an instance of <see cref="PersistentCountByIntervalAwaitableConstraint"/>.
+        /// </summary>
+        /// <param name="count">Maximum actions allowed per time interval.</param>
+        /// <param name="timeSpan">Time interval limits are applied for.</param>
+        /// <param name="saveStateAction">Action is used to save state.</param>
+        /// <param name="initialTimeStamps">Initial timestamps.</param>
+        public PersistentCountByIntervalAwaitableConstraint(int count, TimeSpan timeSpan,
+            Action<DateTime> saveStateAction, IEnumerable<DateTime> initialTimeStamps) : base(count, timeSpan)
+        {
+            _saveStateAction = saveStateAction;
+
+            if (initialTimeStamps == null)
+                return;
+
+            foreach (var timeStamp in initialTimeStamps)
+            {
+                _TimeStamps.Push(timeStamp);
+            }
+        }
+
+        /// <summary>
+        /// Add new timestamp, save state, and release semaphore for next iterations.
+        /// </summary>
+        protected override void OnEnded()
+        {
+            var now = _Time.GetNow();
+            _TimeStamps.Push(now);
+            _saveStateAction(now);
+            _Semafore.Release();
+        }
+    }
+}

--- a/RateLimiter/RateLimiter.csproj
+++ b/RateLimiter/RateLimiter.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PersistentCountByIntervalAwaitableConstraint.cs" />
     <Compile Include="ComposedAwaitableConstraint.cs" />
     <Compile Include="CountByIntervalAwaitableConstraint.cs" />
     <Compile Include="DisposeAction.cs" />

--- a/RateLimiter/TimeLimiter.cs
+++ b/RateLimiter/TimeLimiter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -78,6 +79,33 @@ namespace RateLimiter
         public static TimeLimiter GetFromMaxCountByInterval(int maxCount, TimeSpan timeSpan)
         {
             return new TimeLimiter(new CountByIntervalAwaitableConstraint(maxCount, timeSpan));
+        }
+
+        /// <summary>
+        /// Create <see cref="TimeLimiter"/> that will save state using action passed through <paramref name="saveStateAction"/> parameter.
+        /// </summary>
+        /// <param name="maxCount">Maximum actions allowed per time interval.</param>
+        /// <param name="timeSpan">Time interval limits are applied for.</param>
+        /// <param name="saveStateAction">Action is used to save state.</param>
+        /// <returns><see cref="TimeLimiter"/> instance with <see cref="PersistentCountByIntervalAwaitableConstraint"/>.</returns>
+        public static TimeLimiter GetPersistentTimeLimiter(int maxCount, TimeSpan timeSpan,
+            Action<DateTime> saveStateAction)
+        {
+            return GetPersistentTimeLimiter(maxCount, timeSpan, saveStateAction, null);
+        }
+
+        /// <summary>
+        /// Create <see cref="TimeLimiter"/> with initial timestamps that will save state using action passed through <paramref name="saveStateAction"/> parameter.
+        /// </summary>
+        /// <param name="maxCount">Maximum actions allowed per time interval.</param>
+        /// <param name="timeSpan">Time interval limits are applied for.</param>
+        /// <param name="saveStateAction">Action is used to save state.</param>
+        /// <param name="initialTimeStamps">Initial timestamps.</param>
+        /// <returns><see cref="TimeLimiter"/> instance with <see cref="PersistentCountByIntervalAwaitableConstraint"/>.</returns>
+        public static TimeLimiter GetPersistentTimeLimiter(int maxCount, TimeSpan timeSpan,
+            Action<DateTime> saveStateAction, IEnumerable<DateTime> initialTimeStamps)
+        {
+            return new TimeLimiter(new PersistentCountByIntervalAwaitableConstraint(maxCount, timeSpan, saveStateAction, initialTimeStamps));
         }
 
         public static TimeLimiter Compose(params IAwaitableConstraint[] constraints)

--- a/RateLimiterTest/PersistentCountByIntervalAwaitableConstraintTest.cs
+++ b/RateLimiterTest/PersistentCountByIntervalAwaitableConstraintTest.cs
@@ -24,13 +24,15 @@ namespace RateLimiterTest
                 (await constraint.WaitForReadiness(CancellationToken.None)).Dispose();
             }
 
-            log.Should().HaveCount(5).And.BeInAscendingOrder();
+            log.Should().HaveCount(5);
         }
 
         [Fact]
         public async Task WaitForReadiness_WithInitialState()
         {
-            var log = new List<DateTime> {new DateTime(2000, 1, 1), new DateTime(2001, 1, 1)};
+            var firstTimeStamp = new DateTime(2000, 1, 1);
+            var secondTimeStamp = new DateTime(2001, 1, 1);
+            var log = new List<DateTime> {firstTimeStamp, secondTimeStamp};
 
             var constraint = new PersistentCountByIntervalAwaitableConstraint(7, TimeSpan.FromSeconds(1),
                 timeStamp => log.Add(timeStamp), log);
@@ -40,7 +42,9 @@ namespace RateLimiterTest
                 (await constraint.WaitForReadiness(CancellationToken.None)).Dispose();
             }
 
-            log.Should().HaveCount(7).And.BeInAscendingOrder();
+            log.Should().HaveCount(7);
+            log[0].Should().Be(firstTimeStamp);
+            log[1].Should().Be(secondTimeStamp);
         }
     }
 }

--- a/RateLimiterTest/PersistentCountByIntervalAwaitableConstraintTest.cs
+++ b/RateLimiterTest/PersistentCountByIntervalAwaitableConstraintTest.cs
@@ -1,0 +1,46 @@
+﻿using RateLimiter;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Xunit;
+using FluentAssertions;
+using System.Threading.Tasks;
+
+namespace RateLimiterTest
+{
+    public class PersistentCountByIntervalAwaitableConstraintTest
+    {
+        [Fact]
+        public async Task WaitForReadiness_WithoutInitialState()
+        {
+            var log = new List<DateTime>();
+
+            var constraint = new PersistentCountByIntervalAwaitableConstraint(1, TimeSpan.FromMilliseconds(200),
+                timeStamp => log.Add(timeStamp), null);
+
+            for (int i = 0; i < 5; i++)
+            {
+                (await constraint.WaitForReadiness(CancellationToken.None)).Dispose();
+            }
+
+            log.Should().HaveCount(5).And.BeInAscendingOrder();
+        }
+
+        [Fact]
+        public async Task WaitForReadiness_WithInitialState()
+        {
+            var log = new List<DateTime> {new DateTime(2000, 1, 1), new DateTime(2001, 1, 1)};
+
+            var constraint = new PersistentCountByIntervalAwaitableConstraint(7, TimeSpan.FromSeconds(1),
+                timeStamp => log.Add(timeStamp), log);
+
+            for (int i = 0; i < 5; i++)
+            {
+                (await constraint.WaitForReadiness(CancellationToken.None)).Dispose();
+            }
+
+            log.Should().HaveCount(7).And.BeInAscendingOrder();
+        }
+    }
+}

--- a/RateLimiterTest/RateLimiterTest.csproj
+++ b/RateLimiterTest/RateLimiterTest.csproj
@@ -75,6 +75,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="PersistentCountByIntervalAwaitableConstraintTest.cs" />
     <Compile Include="ComposedAwaitableConstraintTest.cs" />
     <Compile Include="CountByIntervalAwaitableConstraintTest.cs" />
     <Compile Include="DisposeActionTest.cs" />


### PR DESCRIPTION
Add a new constraint that allows saving time stamps to an external destination. E.g. to allow using RateLimiter after application relaunch with previously created timestamps.